### PR TITLE
Undefined name: import numbers

### DIFF
--- a/netdissect/modelconfig.py
+++ b/netdissect/modelconfig.py
@@ -1,3 +1,4 @@
+import numbers
 import torch
 from netdissect.autoeval import autoimport_eval
 from netdissect.progress import print_progress

--- a/netdissect/tool/allunitsample.py
+++ b/netdissect/tool/allunitsample.py
@@ -3,7 +3,7 @@ A simple tool to generate sample of output of a GAN,
 subject to filtering, sorting, or intervention.
 '''
 
-import torch, numpy, os, argparse, sys, shutil, errno
+import torch, numpy, os, argparse, sys, shutil, errno, numbers
 from PIL import Image
 from torch.utils.data import TensorDataset
 from netdissect.zdataset import standard_z_sample

--- a/netdissect/tool/makesample.py
+++ b/netdissect/tool/makesample.py
@@ -3,7 +3,7 @@ A simple tool to generate sample of output of a GAN,
 subject to filtering, sorting, or intervention.
 '''
 
-import torch, numpy, os, argparse, sys, shutil
+import torch, numpy, os, argparse, numbers, sys, shutil
 from PIL import Image
 from torch.utils.data import TensorDataset
 from netdissect.zdataset import standard_z_sample


### PR DESCRIPTION
__numbers.Number__ is used these three files but __numbers__ is never imported.  This means that it is an _undefined name_ that has the potential to halt the script by raising [__NameError__](https://docs.python.org/3/library/exceptions.html#NameError) at runtime.

[flake8](http://flake8.pycqa.org) testing of https://github.com/CSAILVision/gandissect on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./netdissect/modelconfig.py:52:42: F821 undefined name 'numbers'
                if isinstance(data[key], numbers.Number):
                                         ^
./netdissect/tool/allunitsample.py:47:42: F821 undefined name 'numbers'
                if isinstance(data[key], numbers.Number):
                                         ^
./netdissect/tool/makesample.py:50:42: F821 undefined name 'numbers'
                if isinstance(data[key], numbers.Number):
                                         ^
3    F821 undefined name 'numbers'
3
```